### PR TITLE
Update SimpleClearCaseSCM.properties

### DIFF
--- a/src/main/resources/jenkins/plugins/simpleclearcase/SimpleClearCaseSCM.properties
+++ b/src/main/resources/jenkins/plugins/simpleclearcase/SimpleClearCaseSCM.properties
@@ -22,6 +22,6 @@
 # THE SOFTWARE.
 
 TimeZone=CEST
-Locale=SE
+Locale=EN
 #quietperiod defined in minutes
 QuietPeriod=10


### PR DESCRIPTION
SCM pooling is not working with SE location if language of jenkins is set to different language from swedish.
Problem was in the date format by the lshistory command.
for example: cleartool setview -exec 'cleartool lshistory -branch <BRANCH> -recurse -since 31-borg-17.16:20:06utc+0000 ...'
English is more common all over the word.